### PR TITLE
Check if the client was properly initialized.

### DIFF
--- a/src/PackageTask.php
+++ b/src/PackageTask.php
@@ -102,6 +102,12 @@ class PackageTask extends AbstractTask
             $projectFilter['ref'] = $this->reference;
         }
 
+        // Check if the client is available.
+        if (!$this->getClient()) {
+            $message = 'Failed to connect. Please ensure the "continuousphp-config" task was executed with a valid token.';
+            throw new \BuildException($message);
+        }
+
         // Get the build list
         $builds = $this->getClient()
             ->getBuilds($projectFilter);


### PR DESCRIPTION
When I try to execute the package task without first authenticating with the config task then I get an unhelpful error:

```
Fatal error: Call to a member function getBuilds() on null in continuousphp/phing-tasks/src/PackageTask.php on line 107
```

It would be better to inform the user to first run the config task.
