### PR TITLE
Use a tokenless client by default.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": ">=5.4.0",
     "phing/phing": "~2.9",
-    "continuousphp/sdk": "~0.1"
+    "continuousphp/sdk": "~0.2"
   },
   "autoload": {
     "psr-4": {

--- a/src/AbstractTask.php
+++ b/src/AbstractTask.php
@@ -12,6 +12,7 @@
 namespace Continuous\Task;
 
 use Continuous\Sdk\Client;
+use Continuous\Sdk\Service;
 
 /**
  * AbstractTask
@@ -40,6 +41,11 @@ abstract class AbstractTask extends \ProjectComponent
      */
     protected function getClient()
     {
+        // If no client has been set previously, default to a client without an
+        // access token. This is useful for accessing public repositories.
+        if (self::$client === NULL) {
+          $this->setClient(Service::factory([]));
+        }
         return self::$client;
     }
 }


### PR DESCRIPTION
If a client with a token was not specifically configured before running the package task, it would be nice to assume that the package is publicly available. We could default to a tokenless client.
