### PR TITLE
Added state param to get packages of one or more specific states only

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ The goal of this task is to setup your credential in order to start consuming
 This task helps you to get a package url for a repository.
 
 #### 2.1. Attributes
-| Name        | Type   | Description                                                         | Default | Required |
-| ----------- | ------ | ------------------------------------------------------------------- | ------- | -------- |
-| provider    | String | the repository provider platform (git-hub, bitbucket...)            | n/a     | Yes      |
-| repository  | String | the repository name                                                 | n/a     | Yes      |
-| reference   | String | the GIT reference of the package                                    | n/a     | No       |
-| destination | String | the GIT reference of the package                                    | n/a     | No       |
-| property    | String | the property in which the download URL or file path will be defined | n/a     | No       |
+| Name        | Type   | Description                                                         | Default  | Required |
+| ----------- | ------ | ------------------------------------------------------------------- | -------- | -------- |
+| provider    | String | the repository provider platform (git-hub, bitbucket...)            | n/a      | Yes      |
+| repository  | String | the repository name                                                 | n/a      | Yes      |
+| reference   | String | the GIT reference of the package                                    | n/a      | No       |
+| state       | String | the allowed build states, can be "complete", "in-progress", or both | complete | No       |
+| destination | String | the Download destination for the package                            | n/a      | No       |
+| property    | String | the property in which the download URL or file path will be defined | n/a      | No       |
 
 #### 2.2 Example
 ```xml
@@ -65,6 +66,7 @@ Download the package by adding the destination
             provider="git-hub"
             repository="continuousphp/phing-tasks"
             reference="refs/heads/master"
+            state="in-progress,complete"
             destination="/tmp"
             property="package.path" />
 ```

--- a/build.xml
+++ b/build.xml
@@ -24,4 +24,14 @@
         <echo message="---PACKAGE_URL:${package.url}---" />
     </target>
 
+    <target name="package-with-state" description="Ouput the package url">
+        <continuousphp-package
+                provider="${provider}"
+                repository="${repository}"
+                reference="${reference}"
+                state="${state}"
+                property="package.url" />
+        <echo message="---PACKAGE_URL:${package.url}---" />
+    </target>
+
 </project>

--- a/features/bootstrap/TaskContext.php
+++ b/features/bootstrap/TaskContext.php
@@ -38,6 +38,11 @@ class TaskContext implements Context, SnippetAcceptingContext
     /**
      * @var string
      */
+    protected $state;
+
+    /**
+     * @var string
+     */
     protected $lastOutput;
     
     /**
@@ -84,6 +89,14 @@ class TaskContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @Given the state :state
+     */
+    public function setState($state)
+    {
+        $this->state = $state;
+    }
+
+    /**
      * @When I use the continuousphp package task
      */
     public function runPackageTask()
@@ -93,7 +106,28 @@ class TaskContext implements Context, SnippetAcceptingContext
                  . " -Dprovider=" . $this->provider
                  . " -Drepository=" . $this->repository
                  . " -Dreference=" . $this->reference;
+
+        exec($command, $output, $return);
+
+        if ($return) {
+            throw new \RuntimeException(implode(PHP_EOL, $output), $return);
+        }
         
+        $this->lastOutput = implode(PHP_EOL, $output);
+    }
+
+    /**
+     * @When I use the continuousphp package-with-state task
+     */
+    public function runPackageWithStateTask()
+    {
+        $command = self::PHING_BIN_PATH . ' config package-with-state'
+            . " -Dtoken=" . $this->token
+            . " -Dprovider=" . $this->provider
+            . " -Drepository=" . $this->repository
+            . " -Dreference=" . $this->reference
+            . " -Dstate=" . $this->state;
+
         exec($command, $output, $return);
         
         if ($return) {

--- a/features/package.feature
+++ b/features/package.feature
@@ -10,3 +10,12 @@ Feature: continuousphp package
     And the reference "refs/heads/master"
     When I use the continuousphp package task
     Then I should retrieve a valid download url
+
+  Scenario: Get the last build of master branch, specifying the state manually
+    Given I've the token "e391f57ddd27bb37097a5c46a47776289cf1eff7"
+    And the provider "git-hub"
+    And the repository "continuousphp/phing-tasks"
+    And the reference "refs/heads/master"
+    And the state "complete,in-progress"
+    When I use the continuousphp package-with-state task
+    Then I should retrieve a valid download url

--- a/src/PackageTask.php
+++ b/src/PackageTask.php
@@ -29,6 +29,11 @@ class PackageTask extends AbstractTask
     /**
      * @var string
      */
+    protected $state;
+
+    /**
+     * @var string
+     */
     protected $provider;
 
     /**
@@ -53,6 +58,25 @@ class PackageTask extends AbstractTask
     public function setReference($reference)
     {
         $this->reference = $reference;
+        
+        return $this;
+    }
+
+    /**
+     * @param string $stateList
+     * @return $this
+     */
+    public function setState($stateList)
+    {
+        $this->state = [];
+        
+        foreach(explode(',', $stateList) as $state) {
+            $state = trim($state);
+
+            if ($state) {
+                $this->state[] = $state;
+            }
+        }
         
         return $this;
     }
@@ -108,19 +132,19 @@ class PackageTask extends AbstractTask
     public function main()
     {
         $projectFilter = [
-            'provider' => $this->provider,
+            'provider'   => $this->provider,
             'repository' => $this->repository,
-            'state' => ['complete'],
-            'result' => ['success', 'warning']
+            'result'     => ['success', 'warning']
         ];
         
+        $projectFilter['state'] = $this->state ? : ['complete'];
+
         if ($this->reference) {
             $projectFilter['ref'] = $this->reference;
         }
 
         // Get the build list
-        $builds = $this->getClient()
-            ->getBuilds($projectFilter);
+        $builds = $this->getClient()->getBuilds($projectFilter);
         
         if (empty($builds['_embedded']['builds'])) {
             $message = 'No build found for the project "' . $this->provider . '/' . $this->repository . '"';

--- a/tests/PackageTaskTest.php
+++ b/tests/PackageTaskTest.php
@@ -58,4 +58,22 @@ class PackageTaskTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($task, $task->setProperty($property));
         $this->assertAttributeSame($property, 'property', $task);
     }
+
+    public function testStateSetter()
+    {
+        $stateList = 'in-progress,complete';
+
+        $task = new PackageTask();
+        $this->assertSame($task, $task->setState($stateList));
+        $this->assertAttributeSame(['in-progress', 'complete'], 'state', $task);
+    }
+
+    public function testStateSetter_WithWhiteSpaces()
+    {
+        $stateList = 'in-progress , complete';
+
+        $task = new PackageTask();
+        $this->assertSame($task, $task->setState($stateList));
+        $this->assertAttributeSame(['in-progress', 'complete'], 'state', $task);
+    }
 }

--- a/tests/PackageTaskTest.php
+++ b/tests/PackageTaskTest.php
@@ -76,4 +76,13 @@ class PackageTaskTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($task, $task->setState($stateList));
         $this->assertAttributeSame(['in-progress', 'complete'], 'state', $task);
     }
+
+    public function testStateSetter_WithEmptyValue()
+    {
+        $stateList = 'in-progress , ';
+
+        $task = new PackageTask();
+        $this->assertSame($task, $task->setState($stateList));
+        $this->assertAttributeSame(['in-progress'], 'state', $task);
+    }
 }


### PR DESCRIPTION
This allows the user to get e.g. also the packages of state "in-progress" by specifying `state="comlpete,in-progress"`. Combined with the default results `success` and `warning`, you should be able to fetch now the packages of builds that are not yet finished because of the code coverage.
